### PR TITLE
Https fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,10 @@
  */
 function GitUrlParse(url) {
 
+    if (typeof url !== "string") {
+        throw new Error("The url must be a string.");
+    }
+
     var urlInfo = {
             protocol: null
           , source: null
@@ -41,7 +45,8 @@ function GitUrlParse(url) {
 
     // HTTP(S) protocol
     check_https: if (/^https?:\/\//.test(url)) {
-        match = url.match(/^(https?):\/\/(.*)\/(.*)\/(.*)(.git)?$/);
+        url = url.replace(/\.git$/, "");
+        match = url.match(/^(https?):\/\/(.*)\/(.*)\/(.*)$/);
         if (!match) { break check_https; }
         urlInfo.protocol = match[1];
         urlInfo.source = match[2];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "giturlparse",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Parses and stringifies git urls.",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
 - `.git` was being part of the name of the repository when using the http(s) protocol
 - check if `url` is a string